### PR TITLE
Implemented `FilterFactory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ $decoded = xzdecode($encoded) or throw new Exception();
 printf('`%s` was decoded from encoded base64(`%s`)', $decoded, base64_encode($encoded));
 ```
 
-## Object-based approach (recommended)
+## Object-based approach
 
 All functionality is available object-wise through the classes [`Lzma`](./src/Lzma.php) and [`Xz`](./src/Xz.php).
 
@@ -19,6 +19,29 @@ $compressed = $xz->compress(b'data');
 $decompressed = $xz->decompress($compressed);
 
 printf('`%s` was decompressed from compressed base64(`%s`)', $decompressed, base64_encode($compressed));
+```
+
+### Filter-based approach
+
+For more complex use cases, a filter-based approach is also possible.
+
+```php
+use PetrKnap\ExternalFilter\Filter;
+use PetrKnap\XzUtils\FilterFactory;
+
+$file = fopen('README.md', 'r');
+$xzFile = tmpfile();
+
+# compress file to file
+FilterFactory::xz()->compress()->filter(input: $file, output: $xzFile);
+
+fclose($file);
+rewind($xzFile);
+
+# decompress file, filter headline and print it
+print FilterFactory::xz()->decompress()->pipe(new Filter('head', ['-n', '1']))->filter($xzFile);
+
+fclose($xzFile);
 ```
 
 ---

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,4 @@
 {
-  "WARNING": "This file is updated automatically. All keys will be overwritten, except of 'conflict', 'keywords', 'require', 'require-dev', 'scripts' and 'suggest'.",
   "autoload": {
     "psr-4": {
       "PetrKnap\\XzUtils\\": "src"
@@ -26,18 +25,19 @@
   ],
   "homepage": "https://github.com/petrknap/php-xz-utils",
   "keywords": [
-    "xz utils",
+    "xz-utils",
     "wrapper",
     "compression",
     "decompression",
-    "xz"
+    "xz",
+    "lzma"
   ],
   "license": "LGPL-3.0-or-later",
   "name": "petrknap/xz-utils",
   "require": {
     "php": ">=8.1",
-    "petrknap/shorts": "^2.0|^3.0",
-    "symfony/process": "^4.0|^5.0|^6.0|^7.0"
+    "petrknap/external-filter": "^1.0",
+    "petrknap/shorts": "^2.0|^3.0"
   },
   "require-dev": {
     "nunomaduro/phpinsights": "^2.11",

--- a/src/FilterFactory.php
+++ b/src/FilterFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\XzUtils;
+
+use PetrKnap\ExternalFilter\Filter;
+
+final class FilterFactory
+{
+    /**
+     * @param non-empty-string $command
+     */
+    private function __construct(
+        private readonly string $command,
+    ) {
+    }
+
+    public static function lzma(): self
+    {
+        return new self('lzma');
+    }
+
+    public static function xz(): self
+    {
+        return new self('xz');
+    }
+
+    /**
+     * @param array<non-empty-string>|null $options
+     */
+    public function compress(
+        int|null $compressionPreset = null,
+        array|null $options = null,
+    ): Filter {
+        $options = ['--compress', ...($options ?? [])];
+        if ($compressionPreset !== null) {
+            $options[] = '-' . $compressionPreset;
+        }
+        return new Filter($this->command, $options);
+    }
+
+    /**
+     * @param array<non-empty-string>|null $options
+     */
+    public function decompress(
+        array|null $options = null,
+    ): Filter {
+        $options = ['--decompress', ...($options ?? [])];
+        return new Filter($this->command, $options);
+    }
+}

--- a/src/Lzma.php
+++ b/src/Lzma.php
@@ -9,11 +9,6 @@ namespace PetrKnap\XzUtils;
  */
 final class Lzma extends XzUtils
 {
-    protected static function command(): string
-    {
-        return 'lzma';
-    }
-
     protected static function compressException(): string
     {
         return Exception\LzmaCouldNotCompressData::class;
@@ -22,5 +17,10 @@ final class Lzma extends XzUtils
     protected static function decompressException(): string
     {
         return Exception\LzmaCouldNotDecompressData::class;
+    }
+
+    protected static function filterFactory(): FilterFactory
+    {
+        return FilterFactory::lzma();
     }
 }

--- a/src/Xz.php
+++ b/src/Xz.php
@@ -9,11 +9,6 @@ namespace PetrKnap\XzUtils;
  */
 final class Xz extends XzUtils
 {
-    protected static function command(): string
-    {
-        return 'xz';
-    }
-
     protected static function compressException(): string
     {
         return Exception\XzCouldNotCompressData::class;
@@ -22,5 +17,10 @@ final class Xz extends XzUtils
     protected static function decompressException(): string
     {
         return Exception\XzCouldNotDecompressData::class;
+    }
+
+    protected static function filterFactory(): FilterFactory
+    {
+        return FilterFactory::xz();
     }
 }

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -21,7 +21,8 @@ final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
     {
         return [
             'ext-xz' => '`data` was decoded from encoded base64(`/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQADZGF0YQB/b0adkp8pwwABHARvLJzBH7bzfQEAAAAABFla`)',
-            'object-based-approach-recommended' => '`data` was decompressed from compressed base64(`/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQADZGF0YQB/b0adkp8pwwABHARvLJzBH7bzfQEAAAAABFla`)',
+            'object-based-approach' => '`data` was decompressed from compressed base64(`/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQADZGF0YQB/b0adkp8pwwABHARvLJzBH7bzfQEAAAAABFla`)',
+            'filter-based-approach' => '# XZ Utils (wrapper)' . PHP_EOL,
         ];
     }
 }

--- a/tests/XzUtilsTestCase.php
+++ b/tests/XzUtilsTestCase.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PetrKnap\XzUtils;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(FilterFactory::class)]
 abstract class XzUtilsTestCase extends TestCase
 {
     private const DATA_B64 = 'h/J4V2gAK1njeEOqyTiTjg==';


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> enum FilterFactory
>> {
>>     case Lzma;
>>     case Xz;
>>
>>     public function compress(
>>         int|null $compressionPreset = null,
>>         array $options = []
>>     ): Filter {/*...*/}
>> 
>>     public function decompress(
>>         array $options = [],
>>     ): Filter {/*...*/}
>> }
>> ```
>
> Sure! Here's a brief summary of the code:
>
> This code defines an enumeration (`enum`) named `FilterFactory` with two cases: `Lzma` and `Xz`. Inside the enumeration, there are two public functions:
> 1. **compress**: This function takes an optional integer parameter called `$compressionPreset` and an array of options (`$options`). It returns an instance of the `Filter` class.
> 2. **decompress**: This function takes an array of options (`$options`) and also returns an instance of the `Filter` class.
>
> Essentially, this enumeration handles compression and decompression methods for the `Lzma` and `Xz` types.
>
>> Could you show me how to use it?
>
> Sure, let me show you an example of how you can use this `FilterFactory` enum with the `compress` and `decompress` methods.
> ```php
> // Example usage of the compress method
> $filterLzma = FilterFactory::Lzma->compress(1, ['option1' => 'value1']);
> $filterXz = FilterFactory::Xz->compress(null, ['option2' => 'value2']);
> 
> // You can now use $filterLzma and $filterXz as instances of the Filter class for further operations.
> ```
>
> In this example:
> - We use the `compress` method on both `Lzma` and `Xz` cases of the `FilterFactory` enum, providing optional parameters for compression preset and options.
> - The resulting instances (`$filterLzma` and `$filterXz`) can then be used as `Filter` objects for further processing.
>
> Feel free to customize the options and parameters based on your specific requirements. Let me know if you have any questions or need further assistance!
>
>> Is there any way to do `FilterFactory` better?
>
> Absolutely, there are a few ways to enhance the `FilterFactory` enum for better readability, maintainability, and performance. Here are some suggestions:
> 1. **Add Type Hints**: Use type hints for method parameters and return types to ensure type safety.
> 2. **Default Values**: Provide sensible default values for method parameters, if possible, to make the methods easier to use.
> 3. **Doc Comments**: Add doc comments to the methods to describe what they do, their parameters, and their return values.
> 4. **Exception Handling**: Implement proper exception handling to manage errors gracefully.
> 5. **Configuration Object**: Instead of using arrays for options, consider creating configuration objects for clarity and type safety.
>
> These enhancements should make your code more robust and maintainable. Let me know if you have any questions or need further adjustments!